### PR TITLE
fix: allow shacl warnings

### DIFF
--- a/shacltool/owl2shacl.py
+++ b/shacltool/owl2shacl.py
@@ -205,7 +205,8 @@ def create_shacl(ontology: str | Path | Graph) -> tuple[Graph, Graph]:
     return ont_graph, sh_graph
 
 
-def rdf_validate(data_file: str | Graph, ont_graph: str | Graph, sh_graph: str | Graph, allow_warnings: bool = False) -> tuple[bool, Graph, str]:
+def rdf_validate(data_file: str | Graph, ont_graph: str | Graph, sh_graph: str | Graph,
+                allow_warnings: bool = False) -> tuple[bool, Graph, str]:
     # run shacl validation
     conforms, results_graph, results_text = validate(data_file,
                                                      shacl_graph=sh_graph,

--- a/shacltool/owl2shacl.py
+++ b/shacltool/owl2shacl.py
@@ -205,7 +205,7 @@ def create_shacl(ontology: str | Path | Graph) -> tuple[Graph, Graph]:
     return ont_graph, sh_graph
 
 
-def rdf_validate(data_file: str | Graph, ont_graph: str | Graph, sh_graph: str | Graph) -> tuple[bool, Graph, str]:
+def rdf_validate(data_file: str | Graph, ont_graph: str | Graph, sh_graph: str | Graph, allow_warnings: bool = False) -> tuple[bool, Graph, str]:
     # run shacl validation
     conforms, results_graph, results_text = validate(data_file,
                                                      shacl_graph=sh_graph,
@@ -213,7 +213,7 @@ def rdf_validate(data_file: str | Graph, ont_graph: str | Graph, sh_graph: str |
                                                      inference='none',
                                                      abort_on_first=False,
                                                      allow_infos=False,
-                                                     allow_warnings=True,
+                                                     allow_warnings=allow_warnings,
                                                      meta_shacl=False,
                                                      advanced=True,
                                                      js=False,

--- a/shacltool/owl2shacl.py
+++ b/shacltool/owl2shacl.py
@@ -213,7 +213,7 @@ def rdf_validate(data_file: str | Graph, ont_graph: str | Graph, sh_graph: str |
                                                      inference='none',
                                                      abort_on_first=False,
                                                      allow_infos=False,
-                                                     allow_warnings=False,
+                                                     allow_warnings=True,
                                                      meta_shacl=False,
                                                      advanced=True,
                                                      js=False,


### PR DESCRIPTION
Allowed warnings to be raised as warnings rather than violations.
- `rdf_validate()` now takes in `allow_warnings` parameter which is passed to the underlying function `validate()`. This gives the user flexibility to specify if they want to allow warmings or not.